### PR TITLE
Script as object and memory improvements for running in process

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -193,8 +193,10 @@ function run(targetScript, options) {
       runner.run();
 
       let shuttingDown = false;
-      process.once('SIGINT', gracefulShutdown);
-      process.once('SIGTERM', gracefulShutdown);
+      if (!process.env.DISABLE_SIGINT_SIGTERM) {
+        process.once('SIGINT', gracefulShutdown);
+        process.once('SIGTERM', gracefulShutdown);
+      }
 
       function gracefulShutdown() {
         debug(`shutting down 🦑`);

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -70,14 +70,19 @@ module.exports.getConfig = function(callback) {
   }
 };
 
-function run(scriptPath, options) {
+function run(targetScript, options) {
   debug('defaultOptions: ', JSON.stringify(defaultOptions, null, 4));
+
+  // Support passing test script as a path or object
+  const isFile = _.isString(targetScript)
+  const scriptPath = isFile ? targetScript : 'script.yml'
+  const passthru = (script, callback) => callback(null, script)
 
   async.waterfall(
     [
-      async.constant(scriptPath),
-      readScript,
-      parseScript,
+      async.constant(targetScript),
+      isFile ? readScript : passthru,
+      isFile ? parseScript : passthru,
       function(script, callback) {
         return callback(null, script, scriptPath, options);
       },
@@ -139,25 +144,27 @@ function run(scriptPath, options) {
         report.phases = _.get(script, 'config.phases', []);
 
         if (options.output) {
-          let logfile = getLogFilename(
-            options.output,
-            defaultOptions.logFilenameFormat
-          );
-          if (!options.quiet) {
-            console.log('Log file: %s', logfile);
+          const output = {
+            aggregate: report,
+            intermediate: intermediates
           }
-          fs.writeFileSync(
-            logfile,
-            JSON.stringify(
-              {
-                aggregate: report,
-                intermediate: intermediates
-              },
-              null,
-              2
-            ),
-            { flag: 'w' }
-          );
+
+          if (_.isFunction(options.output)) {
+            options.output(output)
+          } else {
+            let logfile = getLogFilename(
+              options.output,
+              defaultOptions.logFilenameFormat
+            );
+            if (!options.quiet) {
+              console.log('Log file: %s', logfile);
+            }
+            fs.writeFileSync(
+              logfile,
+              JSON.stringify(output, null, 2),
+              { flag: 'w' }
+            );
+          }
         }
 
         if (script.config.ensure) {

--- a/lib/runner-sp.js
+++ b/lib/runner-sp.js
@@ -74,30 +74,32 @@ Runner.prototype.run = function() {
 
     runner.run();
 
-    const MELTING_POINT = process.env.ARTILLERY_CPU_THRESHOLD || 90;
-    const CPU_CHECK_INTERVAL_MS = 2500;
-    const CPU_HOT_BEFORE_WARN = (process.env.CPU_HOT_BEFORE_WARN || 10) * 1000;
-    let mpe = 0;
+    if (!process.env.DISABLE_CPU_CHECK) {
+      const MELTING_POINT = process.env.ARTILLERY_CPU_THRESHOLD || 90;
+      const CPU_CHECK_INTERVAL_MS = 2500;
+      const CPU_HOT_BEFORE_WARN = (process.env.CPU_HOT_BEFORE_WARN || 10) * 1000;
+      let mpe = 0;
 
-    setInterval(
-      function checkCPU() {
-        pidusage.stat(process.pid, function(err, pidStats) {
-          if (err) {
-            debug(err);
-            return;
-          }
+      setInterval(
+        function checkCPU() {
+          pidusage.stat(process.pid, function (err, pidStats) {
+            if (err) {
+              debug(err);
+              return;
+            }
 
-          if (pidStats && pidStats.cpu && pidStats.cpu >= MELTING_POINT) {
-            mpe++;
-          }
+            if (pidStats && pidStats.cpu && pidStats.cpu >= MELTING_POINT) {
+              mpe++;
+            }
 
-          if (mpe * CPU_CHECK_INTERVAL_MS >= CPU_HOT_BEFORE_WARN) {
-            self.events.emit('highcpu', [process.pid]);
-            mpe = 0;
-          }
-        });
-      },
-      CPU_CHECK_INTERVAL_MS).unref();
+            if (mpe * CPU_CHECK_INTERVAL_MS >= CPU_HOT_BEFORE_WARN) {
+              self.events.emit('highcpu', [process.pid]);
+              mpe = 0;
+            }
+          });
+        },
+        CPU_CHECK_INTERVAL_MS).unref();
+    }
   }).catch(function(err) {
     // TODO: Handle the error
     console.log(err);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -121,7 +121,7 @@ Runner.prototype.run = function run() {
   const CPU_CHECK_INTERVAL_MS = 2500;
   const CPU_HOT_BEFORE_WARN = (process.env.CPU_HOT_BEFORE_WARN || 10) * 1000;
   let mpe = 0;
-  setInterval(function() {
+  this._cpuInterval = setInterval(function() {
     A.map(
       Object.keys(self._workers),
       pidusage.stat,
@@ -150,6 +150,8 @@ Runner.prototype.run = function run() {
 
 Runner.prototype.shutdown = function(done) {
   let self = this;
+  clearInterval(this._cpuInterval)
+
   A.eachSeries(
     Object.keys(this._workers),
     function(pid, next) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -116,34 +116,38 @@ Runner.prototype.run = function run() {
     this._script.config.statsInterval * 1000
   );
 
-  // Watch CPU usage of child processes:
-  const MELTING_POINT = process.env.ARTILLERY_CPU_THRESHOLD || 90;
-  const CPU_CHECK_INTERVAL_MS = 2500;
-  const CPU_HOT_BEFORE_WARN = (process.env.CPU_HOT_BEFORE_WARN || 10) * 1000;
-  let mpe = 0;
-  this._cpuInterval = setInterval(function() {
-    A.map(
-      Object.keys(self._workers),
-      pidusage.stat,
-      function cpuCollected(err, pidStats) {
-        if (err) {
-          return;
-        }
-        debug('cpu usage:', pidStats.map((o) => { return o.cpu; }));
-        const busyPids = pidStats.filter(function(o) {
-          return o && o.cpu && o.cpu >= MELTING_POINT;
-        });
-        if (busyPids.length > 0) {
-          mpe++;
-        }
+  if (!process.env.DISABLE_CPU_CHECK) {
+    // Watch CPU usage of child processes:
+    const MELTING_POINT = process.env.ARTILLERY_CPU_THRESHOLD || 90;
+    const CPU_CHECK_INTERVAL_MS = 2500;
+    const CPU_HOT_BEFORE_WARN = (process.env.CPU_HOT_BEFORE_WARN || 10) * 1000;
+    let mpe = 0;
+    this._cpuInterval = setInterval(function () {
+      A.map(
+        Object.keys(self._workers),
+        pidusage.stat,
+        function cpuCollected(err, pidStats) {
+          if (err) {
+            return;
+          }
+          debug('cpu usage:', pidStats.map((o) => {
+            return o.cpu;
+          }));
+          const busyPids = pidStats.filter(function (o) {
+            return o && o.cpu && o.cpu >= MELTING_POINT;
+          });
+          if (busyPids.length > 0) {
+            mpe++;
+          }
 
-        if (mpe * CPU_CHECK_INTERVAL_MS >= CPU_HOT_BEFORE_WARN) {
-          self.events.emit('highcpu', busyPids);
-          mpe = 0;
-        }
-        debug('busyPids:', busyPids);
-      });
-  }, CPU_CHECK_INTERVAL_MS).unref();
+          if (mpe * CPU_CHECK_INTERVAL_MS >= CPU_HOT_BEFORE_WARN) {
+            self.events.emit('highcpu', busyPids);
+            mpe = 0;
+          }
+          debug('busyPids:', busyPids);
+        });
+    }, CPU_CHECK_INTERVAL_MS).unref();
+  }
 
   return this;
 };


### PR DESCRIPTION
In addition to the in-memory handling of the script and Artillery output, this PR contains fixes to allow disabling of some functionality that poses problems when Artillery is invoked multiple times in the same process.

This is intended to be an unblocking fix to enable the use of monitoring mode with scripts that contain significant payloads.

Happy to discuss alternatives to the wholesale disabling of these blocks of code via EV.