### PR TITLE
Add WebSocket URL templating

### DIFF
--- a/core/lib/engine_ws.js
+++ b/core/lib/engine_ws.js
@@ -98,7 +98,10 @@ WSEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
 
       ee.emit('started');
 
-      let ws = new WebSocket(config.target, options);
+      const wsUrl = template(config.target, initialContext);
+
+      let ws = new WebSocket(wsUrl, options);
+
       ws.on('open', function() {
         initialContext.ws = ws;
         return callback(null, initialContext);


### PR DESCRIPTION
When doing WS load testing against AWS API Gateway Websocket using a lambda authorizer we had to pass the credentials (token) through query string in the websocket url, since AWS doesn't support parameters and auth using header for AWS API Gateway Websocket functionality.

In order to fix that I needed templating in the target URL when using the WS engine, and to achieve this functionality was just a matter of calling the `template` function when creating the WebSocket client.