### PR TITLE
Add WebSocket URL templating

### DIFF
--- a/core/lib/engine_ws.js
+++ b/core/lib/engine_ws.js
@@ -98,7 +98,10 @@ WSEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
 
       ee.emit('started');
 
-      let ws = new WebSocket(config.target, options);
+      const wsUrl = template(config.target, initialContext);
+
+      let ws = new WebSocket(wsUrl, options);
+
       ws.on('open', function() {
         initialContext.ws = ws;
         return callback(null, initialContext);

--- a/core/lib/engine_ws.js
+++ b/core/lib/engine_ws.js
@@ -42,7 +42,9 @@ WSEngine.prototype.step = function (requestSpec, ee) {
       steps,
       {
         loopValue: requestSpec.loopValue || '$loopCount',
-        overValues: requestSpec.over
+        overValues: requestSpec.over,
+        whileTrue: self.config.processor ?
+          self.config.processor[requestSpec.whileTrue] : undefined
       });
   }
 
@@ -50,11 +52,8 @@ WSEngine.prototype.step = function (requestSpec, ee) {
     return engineUtil.createThink(requestSpec, _.get(self.config, 'defaults.think', {}));
   }
 
-  let f = function(context, callback) {
-    ee.emit('request');
-    let startedAt = process.hrtime();
-
-    if (requestSpec.function) {
+  if (requestSpec.function) {
+    return function(context, callback) {
       let processFunc = self.config.processor[requestSpec.function];
       if (processFunc) {
         processFunc(context, ee, function () {
@@ -62,6 +61,11 @@ WSEngine.prototype.step = function (requestSpec, ee) {
         });
       }
     }
+  }
+
+  let f = function(context, callback) {
+    ee.emit('request');
+    let startedAt = process.hrtime();
 
     let payload = template(requestSpec.send, context);
     if (typeof payload === 'object') {
@@ -93,31 +97,38 @@ WSEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
 
   return function scenario(initialContext, callback) {
     function zero(callback) {
-      let tls = config.tls || {}; // TODO: config.tls is deprecated
+      let tls = config.tls || {};
       let options = _.extend(tls, config.ws);
+
+      let subprotocols = _.get(config, 'ws.subprotocols', []);
+      const headers = _.get(config, 'ws.headers', {});
+      const subprotocolHeader = _.find(headers, (value, headerName) => {
+        return headerName.toLowerCase() === 'sec-websocket-protocol';
+      });
+      if (typeof subprotocolHeader !== 'undefined') {
+        // NOTE: subprotocols defined via config.ws.subprotocols take precedence:
+        subprotocols = subprotocols.concat(subprotocolHeader.split(',').map(s => s.trim()));
+      }
 
       ee.emit('started');
 
       const wsUrl = template(config.target, initialContext);
 
-      let ws = new WebSocket(wsUrl, options);
+      let ws = new WebSocket(wsUrl, subprotocols, options);
 
       ws.on('open', function() {
         initialContext.ws = ws;
         return callback(null, initialContext);
       });
+
       ws.once('error', function(err) {
         debug(err);
-        ee.emit('error', err.code);
+        ee.emit('error', err.message || err.code);
         return callback(err, {});
       });
     }
 
     initialContext._successCount = 0;
-    initialContext._pendingRequests = _.size(
-      _.reject(scenarioSpec, function(rs) {
-        return (typeof rs.think === 'number');
-      }));
 
     let steps = _.flatten([
       zero,


### PR DESCRIPTION
When doing WS load testing against AWS API Gateway Websocket using a lambda authorizer we had to pass the credentials (token) through query string in the websocket url, since AWS doesn't support parameters and auth using header for AWS API Gateway Websocket functionality.

In order to fix that I needed templating in the target URL when using the WS engine, and to achieve this functionality was just a matter of calling the template function when creating the WebSocket client.

Also a backport from Artillery main branch was needed to actually use a function inside the ws scenario flow